### PR TITLE
Add Magento repository and dev-dependencies needed for Scrutinizer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,11 +5,22 @@
         "php": "~7.0.0",
         "magento/framework": "100.1.*"
     },
+      "require-dev": {
+    "magento/marketplace-eqp": "~1.0.5",
+    "magento-ecg/coding-standard": "2.*",
+    "phpunit/phpunit": "4.1.0"
+  },
     "type": "magento2-module",
     "version": "1.0.1",
     "license": [
         "proprietary"
     ],
+      "repositories": {
+    "magento": {
+      "type": "composer",
+      "url": "https://repo.magento.com/"
+    }
+  },
     "autoload": {
         "files": [
             "registration.php"


### PR DESCRIPTION
In order to configure scrutinizer we need to add Magento repository as well as some dev dependencies for it to use when building the build.